### PR TITLE
Add additional options to importer

### DIFF
--- a/src/peakrdl_ipxact/__peakrdl__.py
+++ b/src/peakrdl_ipxact/__peakrdl__.py
@@ -79,10 +79,22 @@ class Importer:
             default=None,
             help="Optional remapState string that is used to select memoryRemap regions that are tagged under a specific remap state."
         )
+        arg_group.add_argument(
+            "--use-ablock-prefix",
+            action="store_true",
+            help="Prefix types with the addressBlock name."
+        )
+        arg_group.add_argument(
+            "--use-component-name",
+            action="store_true",
+            help="For single memoryMap designs, use the comonent name instead of the memoryMap name."
+        )
 
     def do_import(self, rdlc: 'RDLCompiler', options: 'argparse.Namespace', path: str) -> None:
         i = IPXACTImporter(rdlc)
         i.import_file(
             path,
-            remap_state=options.remap_state
+            remap_state=options.remap_state,
+            use_ablock_prefix=options.use_ablock_prefix,
+            use_component_name=options.use_component_name
         )

--- a/src/peakrdl_ipxact/__peakrdl__.py
+++ b/src/peakrdl_ipxact/__peakrdl__.py
@@ -79,22 +79,10 @@ class Importer:
             default=None,
             help="Optional remapState string that is used to select memoryRemap regions that are tagged under a specific remap state."
         )
-        arg_group.add_argument(
-            "--use-ablock-prefix",
-            action="store_true",
-            help="Prefix types with the addressBlock name."
-        )
-        arg_group.add_argument(
-            "--use-component-name",
-            action="store_true",
-            help="For single memoryMap designs, use the comonent name instead of the memoryMap name."
-        )
 
     def do_import(self, rdlc: 'RDLCompiler', options: 'argparse.Namespace', path: str) -> None:
         i = IPXACTImporter(rdlc)
         i.import_file(
             path,
-            remap_state=options.remap_state,
-            use_ablock_prefix=options.use_ablock_prefix,
-            use_component_name=options.use_component_name
+            remap_state=options.remap_state
         )

--- a/src/peakrdl_ipxact/importer.py
+++ b/src/peakrdl_ipxact/importer.py
@@ -31,7 +31,7 @@ class IPXACTImporter(RDLImporter):
         return self.default_src_ref
 
 
-    def import_file(self, path: str, remap_state: Optional[str] = None, use_ablock_prefix: bool = False, use_component_name: bool = False) -> None:
+    def import_file(self, path: str, remap_state: Optional[str] = None) -> None:
         """
         Import a single SPIRIT or IP-XACT file into the SystemRDL namespace.
 
@@ -42,10 +42,6 @@ class IPXACTImporter(RDLImporter):
         remap_state:
             Optional remapState string that is used to select memoryRemap regions
             that are tagged under a specific remap state.
-        use_ablock_prefix:
-            Prefix types with the addressBlock name
-        use_component_name:
-            For single memoryMap designs, use the comonent name instead of the memoryMap name
         """
         super().import_file(path)
 
@@ -57,29 +53,11 @@ class IPXACTImporter(RDLImporter):
         component = self.get_component(dom)
 
         memoryMaps = self.get_all_memoryMap(component)
-        if len(memoryMaps) == 1:
-            # Only one memory map in this component
-            # Use simplified import naming scheme, preserving original memoryMap
-            # and addressBlock names as much as possible.
 
-            # Occasionally, some documents will use the same name for the memoryMap
-            # and addressBlock.
-            # If this happens, add a suffix to the mmap name to prevent the import collision
-
-            # Optionally, use the component name instead of the memory map name
-            if use_component_name:
-                mmap_name = self.get_sanitized_element_name(component)
-            else:
-                mmap_name = self.get_sanitized_element_name(memoryMaps[0])
-            for addressBlock in self.get_all_address_blocks(memoryMaps[0], remap_state):
-                ablock_name = self.get_sanitized_element_name(addressBlock)
-                if mmap_name == ablock_name:
-                    mmap_name += "_mmap"
-
-            self.import_memoryMap(memoryMaps[0], remap_state, override_mmap_name=mmap_name, use_ablock_prefix=use_ablock_prefix)
-        else:
-            for memoryMap in memoryMaps:
-                self.import_memoryMap(memoryMap, remap_state, use_ablock_prefix=True)
+        for memoryMap in memoryMaps:
+            comp_name = self.get_sanitized_element_name(component)
+            mmap_name = self.get_sanitized_element_name(memoryMap)
+            self.import_memoryMap(memoryMap, remap_state, override_mmap_name=f"{comp_name}__{mmap_name}", use_ablock_prefix=True)
 
 
     def get_component(self, dom: minidom.Element) -> minidom.Element:

--- a/src/peakrdl_ipxact/importer.py
+++ b/src/peakrdl_ipxact/importer.py
@@ -31,7 +31,7 @@ class IPXACTImporter(RDLImporter):
         return self.default_src_ref
 
 
-    def import_file(self, path: str, remap_state: Optional[str] = None) -> None:
+    def import_file(self, path: str, remap_state: Optional[str] = None, use_ablock_prefix: bool = False, use_component_name: bool = False) -> None:
         """
         Import a single SPIRIT or IP-XACT file into the SystemRDL namespace.
 
@@ -42,6 +42,10 @@ class IPXACTImporter(RDLImporter):
         remap_state:
             Optional remapState string that is used to select memoryRemap regions
             that are tagged under a specific remap state.
+        use_ablock_prefix:
+            Prefix types with the addressBlock name
+        use_component_name:
+            For single memoryMap designs, use the comonent name instead of the memoryMap name
         """
         super().import_file(path)
 
@@ -61,13 +65,18 @@ class IPXACTImporter(RDLImporter):
             # Occasionally, some documents will use the same name for the memoryMap
             # and addressBlock.
             # If this happens, add a suffix to the mmap name to prevent the import collision
-            mmap_name = self.get_sanitized_element_name(memoryMaps[0])
+
+            # Optionally, use the component name instead of the memory map name
+            if use_component_name:
+                mmap_name = self.get_sanitized_element_name(component)
+            else:
+                mmap_name = self.get_sanitized_element_name(memoryMaps[0])
             for addressBlock in self.get_all_address_blocks(memoryMaps[0], remap_state):
                 ablock_name = self.get_sanitized_element_name(addressBlock)
                 if mmap_name == ablock_name:
                     mmap_name += "_mmap"
 
-            self.import_memoryMap(memoryMaps[0], remap_state, override_mmap_name=mmap_name)
+            self.import_memoryMap(memoryMaps[0], remap_state, override_mmap_name=mmap_name, use_ablock_prefix=use_ablock_prefix)
         else:
             for memoryMap in memoryMaps:
                 self.import_memoryMap(memoryMap, remap_state, use_ablock_prefix=True)


### PR DESCRIPTION
- Add option to use component name instead of memory map name
- Add option to always prefix address blocks with memory map name

The combination of these options allows you to import two IPs with matching ipxact files where only the component name is different.