### PR TITLE
Add name_filter_regex to ipxact importer.

### DIFF
--- a/src/peakrdl_ipxact/importer.py
+++ b/src/peakrdl_ipxact/importer.py
@@ -674,7 +674,7 @@ class IPXACTImporter(RDLImporter):
             # Non-volatile fields cannot be hardware writable. 'volatile'
             # defaults to False.
             if 'volatile' not in d or not d['volatile']:
-              self.assign_property(C, 'hw', rdltypes.AccessType.r)
+                self.assign_property(C, 'hw', rdltypes.AccessType.r)
 
         if 'enum_el' in d:
             enum_type = self.parse_enumeratedValues(d['enum_el'], C.inst_name + "_enum_t")

--- a/tests/unittest_utils.py
+++ b/tests/unittest_utils.py
@@ -1,8 +1,9 @@
 import os
 import unittest
 import subprocess
+import tempfile
+from typing import Optional
 import logging
-import pytest
 
 from systemrdl import RDLCompiler
 from systemrdl.messages import MessagePrinter
@@ -21,14 +22,24 @@ class TestPrinter(MessagePrinter):
 
 class IPXACTTestCase(unittest.TestCase):
 
+    def setUp(self):
+      super().setUp()
+      self.tempdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+      self.tempdir.cleanup()
+      super().tearDown()
+
     #: this gets auto-loaded via the _load_request autouse fixture
     request = None # type: pytest.FixtureRequest
 
-    @pytest.fixture(autouse=True)
     def _load_request(self, request):
         self.request = request
 
-    def compile(self, files, top_name=None):
+    def compile(self,
+                files,
+                top_name=None,
+                name_filter_regex: Optional[str]=None):
         rdlc = RDLCompiler(
             message_printer=TestPrinter()
         )
@@ -38,7 +49,7 @@ class IPXACTTestCase(unittest.TestCase):
             if file.endswith(".rdl"):
                 rdlc.compile_file(file)
             elif file.endswith(".xml"):
-                ipxact.import_file(file)
+                ipxact.import_file(file, name_filter_regex=name_filter_regex)
         return rdlc.elaborate(top_name, "top")
 
     def compare_nodes(self, a: Node, b: Node):
@@ -59,7 +70,6 @@ class IPXACTTestCase(unittest.TestCase):
         for prop in props:
             if prop not in check_props:
                 continue
-            print(prop, a, b)
             self.assertEqual(a.get_property(prop), b.get_property(prop))
 
     def export(self, node, file, std):


### PR DESCRIPTION
    Can be used to compile only specific elements from xml sources.
    
    Useful when building a SoC that requires only specific registers from a
    very large IP-XACT file that contains 000s of registers.
    
    Required when importing registers from A.xml and B.xml but where A and B
    each define same-named components, which causes a "multiple type" error
    unless only the specifically required registers are imported.
