### PR TITLE
Handle IP-XACT parameters

### DIFF
--- a/src/peakrdl_ipxact/__about__.py
+++ b/src/peakrdl_ipxact/__about__.py
@@ -1,2 +1,2 @@
-version_info = (3, 5, 0)
+version_info = (3, 5, 1)
 __version__ = ".".join([str(n) for n in version_info])

--- a/src/peakrdl_ipxact/__peakrdl__.py
+++ b/src/peakrdl_ipxact/__peakrdl__.py
@@ -90,10 +90,18 @@ class Importer(ImporterPlugin):
             help="If True, allow empty IPXact registers to imported as SystemRDL registers without fields"
         )
 
+        arg_group.add_argument(
+            "--config",
+            type=str,
+            required=False,
+            help="Path to the parameter override configuration file"
+        )
+
     def do_import(self, rdlc: 'RDLCompiler', options: 'argparse.Namespace', path: str) -> None:
         i = IPXACTImporter(rdlc)
         i.import_file(
             path,
             remap_state=options.remap_state,
-            allow_empty_regs=options.allow_empty_regs
+            allow_empty_regs=options.allow_empty_regs,
+            config=options.config
         )

--- a/src/peakrdl_ipxact/__peakrdl__.py
+++ b/src/peakrdl_ipxact/__peakrdl__.py
@@ -83,9 +83,17 @@ class Importer(ImporterPlugin):
             help="Optional remapState string that is used to select memoryRemap regions that are tagged under a specific remap state."
         )
 
+        arg_group.add_argument(
+            "--allow-empty-regs",
+            action="store_true",
+            default=False,
+            help="If True, allow empty IPXact registers to imported as SystemRDL registers without fields"
+        )
+
     def do_import(self, rdlc: 'RDLCompiler', options: 'argparse.Namespace', path: str) -> None:
         i = IPXACTImporter(rdlc)
         i.import_file(
             path,
-            remap_state=options.remap_state
+            remap_state=options.remap_state,
+            allow_empty_regs=options.allow_empty_regs
         )


### PR DESCRIPTION
The following pull request contains 2 new features I ran into while trying to import IP-XACT files from a very large, well known 3-letter IP vendor.
The IP in question is quite old, using SPIRIT 1.4 IP-XACT files. Other IPs from the same versions which I have have moved to IEEE1685-2009, but both still use the XPATH expression language for parameters.
The pull request below has actually 2 separate pull requests.

The first commit, ce3e534b4e337e11ab33f8ac19a4a130b567f76a, allows importing empty register definition without fields. The vendor uses these when it has read only registers containing a reset value of 0. I don't know if this is legal in IP-XACT, but in SystemRDL a register must have at least one field.

The other 2 commits (which can be squashed) add the ability to parse IP-XACT parameter expressions (see Annex E in IEEE1685-2009), including spirit:decode(), spirit:log() and spirit:pow() functions. I didn't implement spirit:containsToken() simply because my IP didn't contain it so I didn't have any reliable test case.

I developed this on Python 3.12, and it adds lxml as a requirement. It is intended to be backward compatible with xml.etree if you don't have lxml installed, but I cannot guarantee that the new functionality will work.

The PR might need some fixes for the following issues:
1. Testing against all supported Python versions
2. Mixed use of "raise" and "self.msg.fatal" (but that was also before).
3. Style changes (mixed use of % and f"")

